### PR TITLE
TOOLS-652 Remove pinned go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: go
 
 sudo: false
 
-go: 1.7
-
 install: make deps
 
 script: make build


### PR DESCRIPTION
due to: https://github.com/golang/go/issues/29233

pw @SharktheFire 
fyi @Jimdo/werkzeugschmiede 